### PR TITLE
fix(display.cpp): issues with #elifdev fix with #elif

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -97,7 +97,7 @@ namespace Display {
         // the latter works in most unix terminals, but not MacOS.
 #ifdef __WIN32__
         *this += "\x1b[s";
-#elifdef __linux__
+#elif __linux__
         *this += "\x1b"
                  "7";
 #endif
@@ -108,7 +108,7 @@ namespace Display {
 // the latter works in most unix terminals, but not MacOS.
 #ifdef __WIN32__
         *this += "\x1b[u";
-#elifdef __linux__
+#elif __linux__
         *this += "\x1b"
                  "8";
 #endif


### PR DESCRIPTION
#elifdef is only availlable since c++23. 
Majority of students are using c++20

https://en.cppreference.com/w/cpp/preprocessor/conditional

fix #37